### PR TITLE
Add Methods for Display in Docs Page

### DIFF
--- a/addons/docs/src/frameworks/web-components/custom-elements.ts
+++ b/addons/docs/src/frameworks/web-components/custom-elements.ts
@@ -14,6 +14,7 @@ interface Tag {
   description: string;
   attributes?: TagItem[];
   properties?: TagItem[];
+  methods?: TagItem[];
   events?: TagItem[];
   slots?: TagItem[];
   cssProperties?: TagItem[];
@@ -26,6 +27,7 @@ interface CustomElements {
 interface Sections {
   attributes?: any;
   properties?: any;
+  methods?: any;
   events?: any;
   slots?: any;
   css?: any;
@@ -59,6 +61,11 @@ export const extractPropsFromElements = (tagName: string, customElements: Custom
   if (metaData.properties) {
     sections.properties = mapData(metaData.properties);
   }
+
+  if (metaData.methods) {
+    sections.methods = mapData(metaData.methods);
+  }
+
   if (metaData.events) {
     sections.events = mapData(metaData.events);
   }


### PR DESCRIPTION
##Issue:
Adding Methods to be displayed in the docs page for Custom Elements

## How to test
Check if Methods section appear in Storybook docs.

## Dependent PR
https://github.com/riversandtechnologies/web-component-analyzer/pull/1
